### PR TITLE
Adding ravendb_database_tasks metric

### DIFF
--- a/ravendb_client.go
+++ b/ravendb_client.go
@@ -27,6 +27,7 @@ type dbStats struct {
 	indexes         []byte
 	databaseStats   []byte
 	storage         []byte
+	tasks           []byte
 }
 
 func initializeClient() {
@@ -84,6 +85,7 @@ func preparePaths(databases []string) []string {
 		paths = append(paths, fmt.Sprintf("/databases/%s/metrics", database))
 		paths = append(paths, fmt.Sprintf("/databases/%s/stats", database))
 		paths = append(paths, fmt.Sprintf("/databases/%s/debug/storage/report", database))
+		paths = append(paths, fmt.Sprintf("/databases/%s/tasks", database))
 	}
 
 	return paths
@@ -184,6 +186,7 @@ func organizeGetResults(results map[string]getResult, databases []string) (*stat
 			metrics:         results[fmt.Sprintf("/databases/%s/metrics", database)].result,
 			databaseStats:   results[fmt.Sprintf("/databases/%s/stats", database)].result,
 			storage:         results[fmt.Sprintf("/databases/%s//debug/storage/report", database)].result,
+			tasks:           results[fmt.Sprintf("/databases/%s/tasks", database)].result,
 		}
 
 		stats.dbStats = append(stats.dbStats, dbs)

--- a/readme.md
+++ b/readme.md
@@ -88,9 +88,9 @@ ravendb_database_size_bytes{database="Demo"} 6.35568128e+08
 ravendb_database_stale_indexes{database="Demo"} 0
 # HELP ravendb_database_tasks Tasks in a database
 # TYPE ravendb_database_tasks gauge
-ravendb_database_tasks{connection_status="Active",database="Demo",name="backup",type="Backup"} 1
-ravendb_database_tasks{connection_status="NotActive",database="Demo",name="DemoSubscriptionTask",type="Subscription"} 1
-ravendb_database_tasks{connection_status="NotActive",database="Demo",name="DemoSubscriptionTask2",type="Subscription"} 1
+ravendb_database_tasks{connection_status="Active",database="Demo",type="Backup"} 2
+ravendb_database_tasks{connection_status="NotActive",database="Demo",type="Backup"} 1
+ravendb_database_tasks{connection_status="NotActive",database="Demo",type="Subscription"} 2
 # HELP ravendb_document_put_bytes_total Server-wide document put bytes
 # TYPE ravendb_document_put_bytes_total counter
 ravendb_document_put_bytes_total 0

--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,12 @@ ravendb_working_set_bytes 1.651195904e+09
 
 ## Changelog
 
+### 0.5.0
+
+* Added two database gauge metrics: `ravendb_database_active_tasks` and `ravendb_database_inactive_tasks`
+
 ### 0.4.0
+
 * Updated golang version, some of the dependencies
 * Used `scratch` as base for the docker image
 

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,11 @@ ravendb_database_size_bytes{database="Demo"} 6.35568128e+08
 # HELP ravendb_database_stale_indexes Count of stale indexes in a database
 # TYPE ravendb_database_stale_indexes gauge
 ravendb_database_stale_indexes{database="Demo"} 0
+# HELP ravendb_database_tasks Tasks in a database
+# TYPE ravendb_database_tasks gauge
+ravendb_database_tasks{connection_status="Active",database="Demo",name="backup",type="Backup"} 1
+ravendb_database_tasks{connection_status="NotActive",database="Demo",name="DemoSubscriptionTask",type="Subscription"} 1
+ravendb_database_tasks{connection_status="NotActive",database="Demo",name="DemoSubscriptionTask2",type="Subscription"} 1
 # HELP ravendb_document_put_bytes_total Server-wide document put bytes
 # TYPE ravendb_document_put_bytes_total counter
 ravendb_document_put_bytes_total 0
@@ -119,7 +124,7 @@ ravendb_working_set_bytes 1.651195904e+09
 
 ### 0.5.0
 
-* Added two database gauge metrics: `ravendb_database_active_tasks` and `ravendb_database_inactive_tasks`
+* Added database gauge metric: `ravendb_database_tasks`
 
 ### 0.4.0
 


### PR DESCRIPTION
## Overview

This pull request introduces two new metrics, ravendb_database_active_tasks and ravendb_database_inactive_tasks, to the RavenDB exporter. These metrics provide valuable insights into the active and inactive tasks within the RavenDB database, enhancing the monitoring capabilities of the exporter.

## Motivation

The addition of these metrics addresses a gap in the current monitoring capabilities of the RavenDB exporter. By exposing information about active and inactive tasks, users gain a deeper understanding of the database's workload and resource utilization. This is particularly crucial for performance analysis, capacity planning, and proactive issue detection through alerting on inactive tasks.

Edit:

This pull request now adds only one metric: `ravendb_database_tasks`